### PR TITLE
Fix burger menu alignment

### DIFF
--- a/style/responsive.css
+++ b/style/responsive.css
@@ -198,7 +198,6 @@
 
   .right-navbar .hamburger {
     display: block;
-    float: right;
   }
 
   .mobile-menu {
@@ -215,14 +214,16 @@
 
   .navbar.responsive .hamburger {
     position: absolute;
-    top: 20px;
+    top: 50%;
     right: 20px;
+    transform: translateY(-50%);
   }
 
   .navbar.responsive a.bookNow {
     position: absolute;
-    top: 21px;
+    top: 50%;
     right: 52px;
+    transform: translateY(-50%);
   }
 
   .navbar.responsive a {

--- a/style/stylesheet.css
+++ b/style/stylesheet.css
@@ -75,10 +75,17 @@ h5 {
 
 .left-navbar {
   display: flex;
+  align-items: center;
+}
+
+.right-navbar {
+  display: flex;
+  align-items: center;
 }
 
 .navbar {
   display: flex;
+  align-items: center;
   background-color: #fff;
   position: absolute;
   top: 50px;


### PR DESCRIPTION
## Summary
- center navbar items so burger menu lines up with the logo and booking link
- keep icons vertically centred when the navbar switches to mobile layout

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ae326758c83228f91885dc804ae39